### PR TITLE
Adding warning class to dot level circle

### DIFF
--- a/ui/src/alerts/components/AlertsTableRow.tsx
+++ b/ui/src/alerts/components/AlertsTableRow.tsx
@@ -60,7 +60,8 @@ class AlertsTableRow extends PureComponent<Props> {
             className={classnames(
               'table-dot',
               {'dot-critical': level === 'CRITICAL'},
-              {'dot-success': level === 'OK'}
+              {'dot-success': level === 'OK'},
+              {'dot-warning': level === 'WARNING'}
             )}
           />
         )}


### PR DESCRIPTION
Class name ommits the WARNING and INFO levels. This commit contains 1 extra line that allows the yellow WARNING to be displayed in the interface.

Closes #

_Briefly describe your proposed changes:_
_What was the problem?_
When navigating to the Alerts -> History, the red dot span, that colors the alert level, do not show the warning color in yellow. There is the class dot-warning available in CSS.
_What was the solution?_
Adding a extra line with an existing css class to display WARNING alerts in the Alert History

  - [] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)